### PR TITLE
Fix browser navigation in manga reader

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -418,7 +418,7 @@ function backToLibrary(pushHistory = true) {
   currentManga = null;
   currentPage  = 1;
   window.scrollTo(0, libraryScrollY);
-  if (pushHistory) history.replaceState({}, "", "/");
+  if (pushHistory) history.pushState({}, "", "/");
 }
 
 function toggleFullscreen() {


### PR DESCRIPTION
## Summary
- preserve history entries when returning to library

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686861f781248330882dbde46c1d4241