### PR TITLE
Add archive/PDF download

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -243,9 +243,52 @@ function createCard(m) {
        ${tags.map(t => `<span class="tag ${t.tType}">${t.name}</span>`).join("")}
      </div>`;
 
+  const dlBtn  = document.createElement('button');
+  dlBtn.className = 'download-btn';
+  dlBtn.textContent = '↓';
+  dlBtn.title = 'Download';
+
+  const menu = document.createElement('div');
+  menu.className = 'download-menu';
+  menu.innerHTML = '<button data-type="archive">Archive</button><button data-type="pdf">PDF</button>';
+
+  dlBtn.onclick = e => {
+    e.stopPropagation();
+    closeAllMenus();
+    menu.style.display = menu.style.display === 'flex' ? 'none' : 'flex';
+  };
+
+  menu.onclick = e => {
+    e.stopPropagation();
+    const type = e.target.dataset.type;
+    if (!type) return;
+    downloadManga(m.number, type);
+    menu.style.display = 'none';
+  };
+
+  card.appendChild(dlBtn);
+  card.appendChild(menu);
+
   if (previewsOn) thumbObserver.observe(card.querySelector(".manga-thumb"));
   return card;
 }
+
+function downloadManga(num, type) {
+  const link = document.createElement('a');
+  link.href = `/api/manga/${num}/${type}`;
+  link.download = '';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+}
+
+function closeAllMenus() {
+  document.querySelectorAll('.download-menu').forEach(m => {
+    m.style.display = 'none';
+  });
+}
+
+document.addEventListener('click', closeAllMenus);
 
 function loadThumb(img) {
   if (img.dataset.loaded) return;

--- a/public/style.css
+++ b/public/style.css
@@ -223,7 +223,7 @@
     display: none
 }
 
-		.manga-card {
+.manga-card {
 			background: linear-gradient(135deg, #2a2a2a, #252525);
 			border-radius: 8px;
 			padding: 10px;
@@ -232,8 +232,56 @@
 			transition: .2s;
 			display: flex;
 			flex-direction: column;
-			align-items: center
-		}
+  align-items: center
+}
+
+                .download-btn {
+                        position: absolute;
+                        top: 6px;
+                        right: 6px;
+                        background: rgba(74, 158, 255, .8);
+                        border: none;
+                        color: #fff;
+                        border-radius: 4px;
+                        font-size: .75rem;
+                        padding: 2px 5px;
+                        cursor: pointer;
+                        display: none
+                }
+
+                .manga-card:hover .download-btn {
+                        display: block
+                }
+
+.manga-grid.compact .download-btn {
+                        display: none !important
+                }
+
+                .download-menu {
+                        position: absolute;
+                        top: 28px;
+                        right: 6px;
+                        background: #2a2a2a;
+                        border: 1px solid #555;
+                        border-radius: 4px;
+                        display: none;
+                        flex-direction: column;
+                        z-index: 50
+                }
+
+                .download-menu button {
+                        background: transparent;
+                        color: #fff;
+                        border: none;
+                        padding: 4px 8px;
+                        font-size: .75rem;
+                        text-align: left;
+                        cursor: pointer
+                }
+
+                .download-menu button:hover {
+                        background: #4a9eff
+                }
 
 		.manga-card:hover {
 			transform: translateY(-4px);

--- a/server.js
+++ b/server.js
@@ -3,6 +3,8 @@ import express from "express";
 import fs from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
+import archiver from "archiver";
+import { PDFDocument } from "pdf-lib";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -10,6 +12,18 @@ const PORT = process.env.PORT ?? 8080;
 const MANGA_DIR = path.resolve("manga"); // folder with 1/, 2/, …
 const AUTH_USER = process.env.AUTH_USER ?? "folly";
 const AUTH_PASS = process.env.AUTH_PASS ?? "shenanigans";
+const SUPPORTED = ["jpg", "jpeg", "png", "webp", "gif", "bmp"];
+
+async function findPage(num, page) {
+  for (const ext of SUPPORTED) {
+    try {
+      const p = path.join(MANGA_DIR, `${num}/${page}.${ext}`);
+      await fs.access(p);
+      return { path: p, ext };
+    } catch {}
+  }
+  return null;
+}
 
 
 const app = express();
@@ -76,6 +90,50 @@ app.get("/api/manga/:num", (req, res) => {
   const entry = mangaCache.find(m => m.number === num);
   if (!entry) return res.status(404).end();
   res.json(entry);
+});
+
+app.get("/api/manga/:num/archive", async (req, res) => {
+  const num = +req.params.num;
+  const entry = mangaCache.find(m => m.number === num);
+  if (!entry) return res.status(404).end();
+  res.setHeader('Content-Type', 'application/zip');
+  res.setHeader('Content-Disposition', `attachment; filename="${num}.zip"`);
+  const archive = archiver('zip', { zlib: { level: 9 } });
+  archive.on('error', err => { console.error(err); res.end(); });
+  archive.pipe(res);
+  for (let i = 1; i <= entry.pages; i++) {
+    const info = await findPage(num, i);
+    if (info) archive.file(info.path, { name: `${i}.${info.ext}` });
+  }
+  archive.file(path.join(MANGA_DIR, `${num}/meta.json`), { name: 'meta.json' });
+  archive.finalize();
+});
+
+app.get("/api/manga/:num/pdf", async (req, res) => {
+  const num = +req.params.num;
+  const entry = mangaCache.find(m => m.number === num);
+  if (!entry) return res.status(404).end();
+  try {
+    const pdf = await PDFDocument.create();
+    for (let i = 1; i <= entry.pages; i++) {
+      const info = await findPage(num, i);
+      if (!info) continue;
+      const data = await fs.readFile(info.path);
+      let img;
+      if (info.ext === 'jpg' || info.ext === 'jpeg') img = await pdf.embedJpg(data);
+      else if (info.ext === 'png') img = await pdf.embedPng(data);
+      else continue;
+      const page = pdf.addPage([img.width, img.height]);
+      page.drawImage(img, { x: 0, y: 0, width: img.width, height: img.height });
+    }
+    const bytes = await pdf.save();
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename="${num}.pdf"`);
+    res.end(Buffer.from(bytes));
+  } catch (err) {
+    console.error(err);
+    res.status(500).end();
+  }
 });
 
 // Serve index.html for direct links like /123/1


### PR DESCRIPTION
## Summary
- add hidden download button with ZIP and PDF options
- implement server endpoints to generate archives and PDFs on-the-fly

## Testing
- `node server.js` *(fails: ENOENT: no such file or directory, scandir 'manga')*

------
https://chatgpt.com/codex/tasks/task_e_686864860c2c833080a832208fb6dcb8