### PR TITLE
Fix PDF creation memory usage

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,12 +1,12 @@
 /* eslint-disable no-console */
 import express from "express";
 import fs from "fs/promises";
-import { createReadStream } from "fs";
+import { createReadStream, createWriteStream } from "fs";
 import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import archiver from "archiver";
-import { PDFDocument } from "pdf-lib";
+import PDFDocument from "pdfkit";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -15,6 +15,17 @@ const MANGA_DIR = path.resolve("manga"); // folder with 1/, 2/, …
 const AUTH_USER = process.env.AUTH_USER ?? "folly";
 const AUTH_PASS = process.env.AUTH_PASS ?? "shenanigans";
 const SUPPORTED = ["jpg", "jpeg", "png", "webp", "gif", "bmp"];
+const TEMP_DIR = path.join(os.tmpdir(), "nhentai-tmp");
+
+async function cleanTempDir() {
+  try {
+    await fs.mkdir(TEMP_DIR, { recursive: true });
+    const files = await fs.readdir(TEMP_DIR);
+    await Promise.all(
+      files.map(f => fs.unlink(path.join(TEMP_DIR, f)).catch(() => {}))
+    );
+  } catch {}
+}
 
 async function findPage(num, page) {
   for (const ext of SUPPORTED) {
@@ -74,6 +85,7 @@ async function buildCache() {
 
 // Build once at start-up
 await buildCache();
+await cleanTempDir();
 
 // Optional: rebuild on demand (lightweight “rescan button”)
 app.post("/api/rescan", async (_req, res) => {
@@ -116,26 +128,28 @@ app.get("/api/manga/:num/pdf", async (req, res) => {
   const entry = mangaCache.find(m => m.number === num);
   if (!entry) return res.status(404).end();
   try {
-    const pdf = await PDFDocument.create();
+    await fs.mkdir(TEMP_DIR, { recursive: true });
+    const tmp = path.join(TEMP_DIR, `${num}-${Date.now()}.pdf`);
+    const out = createWriteStream(tmp);
+    const pdf = new PDFDocument({ autoFirstPage: false });
+    pdf.pipe(out);
+
     for (let i = 1; i <= entry.pages; i++) {
       const info = await findPage(num, i);
       if (!info) continue;
-      const data = await fs.readFile(info.path);
-      let img;
-      if (info.ext === 'jpg' || info.ext === 'jpeg') img = await pdf.embedJpg(data);
-      else if (info.ext === 'png') img = await pdf.embedPng(data);
-      else continue;
-      const page = pdf.addPage([img.width, img.height]);
-      page.drawImage(img, { x: 0, y: 0, width: img.width, height: img.height });
+      const img = pdf.openImage(info.path);
+      pdf.addPage({ size: [img.width, img.height], margin: 0 });
+      pdf.image(img, 0, 0);
     }
-    const bytes = await pdf.save();
-    const tmp = path.join(os.tmpdir(), `${num}-${Date.now()}.pdf`);
-    await fs.writeFile(tmp, Buffer.from(bytes));
-    res.setHeader('Content-Type', 'application/pdf');
-    res.setHeader('Content-Disposition', `attachment; filename="${num}.pdf"`);
-    const stream = createReadStream(tmp);
-    stream.pipe(res);
-    stream.on('close', () => fs.unlink(tmp).catch(() => {}));
+
+    pdf.end();
+    out.on('close', () => {
+      res.setHeader('Content-Type', 'application/pdf');
+      res.setHeader('Content-Disposition', `attachment; filename="${num}.pdf"`);
+      const stream = createReadStream(tmp);
+      stream.pipe(res);
+      stream.on('close', () => fs.unlink(tmp).catch(() => {}));
+    });
   } catch (err) {
     console.error(err);
     res.status(500).end();
@@ -156,6 +170,12 @@ app.use((req, res) => {
 });
 
 // -------- Start --------------------------------------------------------------
+function gracefulExit() {
+  cleanTempDir().finally(() => process.exit());
+}
+process.on('SIGINT', gracefulExit);
+process.on('SIGTERM', gracefulExit);
+
 app.listen(PORT, () =>
   console.log(`🚀  http://localhost:${PORT}  (cache ${mangaCache.length})`)
 );


### PR DESCRIPTION
## Summary
- switch PDF generation to use pdfkit with streaming
- use a dedicated temp directory and cleanup routine for downloads

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node -c server.js && python3 -m py_compile main.py main2.py`


------
https://chatgpt.com/codex/tasks/task_e_686872c6b3188330873c7cf90f86a214