### PR TITLE
Fix direct links to specific manga pages

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -425,6 +425,7 @@ function updateCounts() {
 }
 
 function updateLibraryURL() {
+  if (!libraryLoaded || pendingRoute) return;
   const url = libraryPage > 1 ? `/?p=${libraryPage}` : "/";
   history.replaceState({}, "", url);
 }

--- a/public/script.js
+++ b/public/script.js
@@ -18,6 +18,7 @@ let currentManga = null;
 let currentPage  = 1;
 let maxPage      = 1;
 let libraryLoaded = false;
+let pendingRoute = null;
 
 /*****************************************************************************
  * INIT                                                                      *
@@ -27,10 +28,11 @@ window.addEventListener("DOMContentLoaded", async () => {
   const p = parseInt(params.get("p") || "1", 10);
   if (!Number.isNaN(p) && p > 0) libraryPage = p;
 
+  handleRoute();                         // record route before data load
   setupUI();
   await loadLibrary();                   // first load
   libraryLoaded = true;
-  handleRoute();
+  handleRoute();                         // apply pending route
   window.addEventListener("popstate", handleRoute);
 });
 
@@ -183,11 +185,19 @@ function cmp(val, op, target) {
 }
 
 function handleRoute() {
-  if (!libraryLoaded) return;
   const match = location.pathname.match(/^\/(\d+)(?:\/(\d+))?$/);
-  if (match) {
-    const num  = parseInt(match[1], 10);
-    const page = match[2] ? parseInt(match[2], 10) : 1;
+
+  if (!libraryLoaded) {
+    pendingRoute = match;
+    return;
+  }
+
+  const route = match || pendingRoute;
+  pendingRoute = null;
+
+  if (route) {
+    const num  = parseInt(route[1], 10);
+    const page = route[2] ? parseInt(route[2], 10) : 1;
     openManga(num, page, false);
   } else {
     backToLibrary(false);

--- a/server.js
+++ b/server.js
@@ -172,13 +172,9 @@ app.get("/api/manga/:num/pdf", async (req, res) => {
   }
 });
 
-// Serve index.html for direct links like /123/1
-app.get("/:num{/:page}", (req, res, next) => {
-  if (/^\d+$/.test(req.params.num)) {
-    res.sendFile(path.join(__dirname, "public", "index.html"));
-  } else {
-    next();
-  }
+// Serve index.html for direct links like /123 or /123/1
+app.get(/^\/(\d+)(?:\/(\d+))?\/?$/, (_req, res) => {
+  res.sendFile(path.join(__dirname, "public", "index.html"));
 });
 // Catch-all 404 page
 app.use((req, res) => {


### PR DESCRIPTION
## Summary
- serve `index.html` for `/123` and `/123/1` routes

## Testing
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_68688aaf27b48330b370f7d2f8848073