### PR TITLE
Improve random selection validation

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -105,8 +105,13 @@ async function buildCache() {
       const metaRaw = await fs.readFile(path.join(MANGA_DIR, `${n}/meta.json`));
       const meta = JSON.parse(metaRaw);
       if (meta.pages > 0) {
-        out.push({ number: n, ...meta });
-        totalPages += meta.pages;
+        const page1 = await findPage(n, 1);
+        if (page1) {
+          out.push({ number: n, ...meta });
+          totalPages += meta.pages;
+        } else {
+          console.warn(`Skipping ${n}: missing images`);
+        }
       }
     } catch (err) {
       console.warn(`Skipping ${n}: ${err.message}`);

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -571,11 +571,33 @@ function togglePreviews() {
   }
 }
 
-function openRandomManga() {
+async function mangaHasFirstPage(num) {
+  for (const ext of supportedFormats) {
+    try {
+      const res = await fetch(
+        `${MANGA_PATH}/${num}/1.${ext}`,
+        { method: "HEAD", headers: authHeaders() }
+      );
+      if (res.ok) return true;
+    } catch {}
+  }
+  return false;
+}
+
+async function openRandomManga() {
   if (!mangaData.length) return;
-  const idx = Math.floor(Math.random() * mangaData.length);
-  const num = mangaData[idx].number;
-  openManga(num, 1, true);
+  const tried = new Set();
+  while (tried.size < mangaData.length) {
+    const idx = Math.floor(Math.random() * mangaData.length);
+    const entry = mangaData[idx];
+    if (tried.has(entry.number)) continue;
+    tried.add(entry.number);
+    if (await mangaHasFirstPage(entry.number)) {
+      openManga(entry.number, 1, true);
+      return;
+    }
+  }
+  alert("No valid manga available.");
 }
 
 /*****************************************************************************


### PR DESCRIPTION
## Summary
- skip manga entries without images during cache build
- check that random selection has a valid first page before opening

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7d22b5408330b9a2d157f242d11f